### PR TITLE
[Feature Request] Allow targeting specific services in the yams CLI

### DIFF
--- a/yams
+++ b/yams
@@ -204,7 +204,7 @@ destroy_yams() {
     fi
 }
 
-start_services() {
+start_yams() {
     # Start all services or specific ones
     if [ "$#" -eq 0 ]; then
         $DC up -d || log_error "Failed to start services"
@@ -215,7 +215,7 @@ start_services() {
     
 }
 
-restart_services() {
+restart_yams() {
     # Restart all services or specific ones
     if [ "$#" -eq 0 ]; then
         $DC stop && $DC up -d
@@ -226,7 +226,7 @@ restart_services() {
     
 }
 
-stop_services() {
+stop_yams() {
     # Stop all services or specific ones
     if [ $# -eq 0 ]; then
         $DC stop || log_error "Failed to stop services"
@@ -250,13 +250,13 @@ main() {
             show_help
             ;;
         restart)
-            restart_services "${@:2}"
+            restart_yams "${@:2}"
             ;;
         stop)
-            stop_services "${@:2}"
+            stop_yams "${@:2}"
             ;;
         start)
-            start_services "${@:2}"
+            start_yams "${@:2}"
             ;;
         check-vpn)
             check_vpn

--- a/yams
+++ b/yams
@@ -180,14 +180,60 @@ backup_yams() {
 }
 
 destroy_yams() {
-    echo -e "\nWARNING: This will destroy all your YAMS services, containers, volumes, and the custom network!"
-    echo "This is not recoverable! ⚠️ 🚨"
-    read -p "Are you sure you want to continue? [y/N]: " -r
-    if [[ ${REPLY,,} =~ ^y$ ]]; then
-        $DC down || log_error "Failed to destroy services"
-        docker network rm yams_network || log_warning "Failed to remove yams_network. It might not exist or was already removed."
-        echo -e "\nYAMS services were destroyed. To restart, run: yams start"
+    # Destroy all services or specific ones
+    if [ "$#" -eq 0 ]; then
+        echo -e "\nWARNING: This will destroy all your YAMS services, containers, volumes, and the custom network!"
+        echo "This is not recoverable! ⚠️ 🚨"
+        read -p "Are you sure you want to continue? [y/N]: " -r
+        if [[ ${REPLY,,} =~ ^y$ ]]; then
+            $DC down || log_error "Failed to destroy services"
+            docker network rm yams_network || log_warning "Failed to remove yams_network. It might not exist or was already removed."
+            echo -e "\nYAMS services were destroyed. To restart, run: yams start"
+        fi
+    else
+        local services=("$@")
+        local target_label=$(printf '%s ' "${services[@]}")
+        echo -e "\nWARNING: This will destroy the following services ${target_label}and their associated containers and volumes!"
+        echo "This is not recoverable! ⚠️ 🚨"
+        read -p "Are you sure you want to continue? [y/N]: " -r
+        if [[ ${REPLY,,} =~ ^y$ ]]; then
+            $DC stop "$@" || log_error "Failed to stop services"
+            $DC rm  -f -v "$@" || log_error "Failed to destroy services"
+            echo -e "\nYAMS service was destroyed. To restart, run: yams start"
+        fi
     fi
+}
+
+start_services() {
+    # Start all services or specific ones
+    if [ "$#" -eq 0 ]; then
+        $DC up -d || log_error "Failed to start services"
+        wait_for_services
+    else
+        $DC up -d "$@" || log_error "Failed to start services" 
+    fi
+    
+}
+
+restart_services() {
+    # Restart all services or specific ones
+    if [ "$#" -eq 0 ]; then
+        $DC stop && $DC up -d
+        wait_for_services
+    else
+        $DC stop "$@" && $DC up -d "$@"
+    fi
+    
+}
+
+stop_services() {
+    # Stop all services or specific ones
+    if [ $# -eq 0 ]; then
+        $DC stop || log_error "Failed to stop services"
+    else
+        $DC stop "$@" || log_error "Failed to stop services: $*"
+    fi
+    log_success "Services stopped successfully"
 }
 
 main() {
@@ -204,22 +250,19 @@ main() {
             show_help
             ;;
         restart)
-            $DC stop && $DC up -d
-            wait_for_services
+            restart_services "${@:2}"
             ;;
         stop)
-            $DC stop || log_error "Failed to stop services"
-            log_success "Services stopped successfully"
+            stop_services "${@:2}"
             ;;
         start)
-            $DC up -d || log_error "Failed to start services"
-            wait_for_services
+            start_services "${@:2}"
             ;;
         check-vpn)
             check_vpn
             ;;
         destroy)
-            destroy_yams
+            destroy_yams "${@:2}"
             ;;
         backup)
             backup_yams "$destination"


### PR DESCRIPTION
Added functionality for the CLI to perform actions on specific services.

### Example of commands:

**Stopping a single specific service**
```
momo@docker:~$ yams stop jellyfin
[+] Stopping 1/1
 ✔ Container jellyfin  Stopped   3.5s 
Services stopped successfully
```

This functionality also allows user to specify multiple services at a time:

**Stopping a multiple specific service's**
```
momo@docker:~$ yams stop jellyfin prowlarr bazarr
[+] Stopping 3/3
 ✔ Container prowlarr  Stopped  3.6s 
 ✔ Container bazarr    Stopped  3.4s 
 ✔ Container jellyfin  Stopped  0.0s 
Services stopped successfully
```

### Implementation Notes

Functionality was spread to multiple functions to make it more readable for contributors, following functions are:

```
start_yams()
stop_yams()
restart_yams()
destroy_yams() (Original function)
```

These functions utilize the ${@:2} parameter to grab all arguments starting from the 2nd one which are the service names.
If no arguments are provided the code works as before running it for all services, otherwise if an argument is provided it only runs the command for a specific service('s).
the docker commands are **case-sensitive** in this case when inputting the services.




