### PR TITLE
ensure custom apps join `yams_network` by default

### DIFF
--- a/docker-compose.custom.yaml
+++ b/docker-compose.custom.yaml
@@ -1,2 +1,7 @@
+networks:
+  default:
+    external: true
+    name: yams_network
+
 # services:  -> When you uncomment, remember to remove the space too! "services:" must be left without any spaces around it
   # Add your custom services here!


### PR DESCRIPTION
Fixes #6 

## Summary
This PR updates `docker.compose.custom.yml` so that all custom services automatically join the `yams_network` instead of the `yams_default` network. This aligns behavior with the documentation under [Network Magic](https://yams.media/advanced/add-your-own-containers/#2-network-magic-).

## Changes
- Added a `networks` section to override the default network.
- Set `default` to point to `yams_network` as an external network.
- Added a comment reminder for developers when adding custom services.

```yaml
networks:
  default:
    external: true
    name: yams_network
```