### PR TITLE
Make yams dozzle user use a hardcoded password hash

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -30,8 +30,6 @@ readonly SUPPORTED_MEDIA_SERVICES=("jellyfin" "emby" "plex")
 readonly DEFAULT_MEDIA_SERVICE="jellyfin"
 readonly DEFAULT_VPN_SERVICE="protonvpn"
 readonly MEDIA_SUBDIRS=("tvshows" "movies" "music" "books" "downloads/usenet/complete" "downloads/usenet/incomplete" "downloads/torrents" "blackhole")
-dozzle_bootstrap_password=""
-
 # Color codes
 readonly RED='\033[0;31m'
 readonly GREEN='\033[0;32m'
@@ -669,34 +667,29 @@ install_cli() {
 setup_dozzle_users() {
     local dozzle_config_dir="$install_directory/config/dozzle"
     local dozzle_users_file="$dozzle_config_dir/users.yml"
-    local dozzle_password_file="$dozzle_config_dir/bootstrap-password.txt"
     mkdir -p "$dozzle_config_dir"
 
     if [ -s "$dozzle_users_file" ]; then
-        if [ -r "$dozzle_password_file" ]; then
-            dozzle_bootstrap_password=$(< "$dozzle_password_file")
-        fi
         log_info "Keeping existing Dozzle users.yml"
         return
     fi
 
-    dozzle_bootstrap_password="yams-$(< /proc/sys/kernel/random/uuid)"
-    if ! docker run --rm amir20/dozzle:latest generate yams \
-        --password "$dozzle_bootstrap_password" --user-roles none > "$dozzle_users_file"; then
-        log_error "Failed to create Dozzle bootstrap user"
-    fi
-    printf '%s\n' "$dozzle_bootstrap_password" > "$dozzle_password_file"
-    chmod 600 "$dozzle_users_file" "$dozzle_password_file" || \
+    # bcrypt hash generated from a random 64 character string
+    local dummy_hash='$2b$11$8HxXT0N1zo5yE4Gdkh7Flu0dIj2vo.D9lqpduBpg/frXkySMjb7g6'
+
+    cat > "$dozzle_users_file" << YAMLEOF
+users:
+  yams:
+    email: ""
+    name: ""
+    password: $dummy_hash
+    filter: ""
+    roles: none
+YAMLEOF
+    chmod 600 "$dozzle_users_file" || \
         log_error "Failed to secure Dozzle bootstrap credentials"
 
     log_success "Dozzle users.yml created ✅"
-}
-
-show_dozzle_bootstrap_credentials() {
-    [ -n "$dozzle_bootstrap_password" ] || return 0
-    log_info "Dozzle bootstrap username: yams"
-    log_info "Dozzle bootstrap password: $dozzle_bootstrap_password"
-    log_warning "Replace the bootstrap user, then remove $install_directory/config/dozzle/bootstrap-password.txt"
 }
 
 set_permissions() {
@@ -745,7 +738,6 @@ update_configuration_files
 
 # Setup initial Dozzle user
 setup_dozzle_users
-show_dozzle_bootstrap_credentials
 
 log_success "Everything installed correctly! 🎉"
 
@@ -787,7 +779,6 @@ EOF
 
 log_success "All done!✅  Enjoy YAMS!"
 log_info "You can check the installation in $install_directory"
-show_dozzle_bootstrap_credentials
 log_info "========================================================"
 log_info "Everything should be running now! To check everything running, go to:"
 echo

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -71,23 +71,18 @@ EOF
     assert_output_contains 'https://yams.media/docs/configure/dozzle/'
 }
 
-@test "creates unique Dozzle bootstrap credentials" {
+@test "creates an unusable Dozzle bootstrap user" {
     install_without_vpn
 
     [ "$status" -eq 0 ]
-    first_install=$INSTALL_DIR
-    grep -Fxq '        roles: none' "$first_install/config/dozzle/users.yml"
-    [ "$(stat -c %a "$first_install/config/dozzle/bootstrap-password.txt")" = 600 ]
-    assert_command "$YAMS_DOCKER_LOG" docker run --rm amir20/dozzle:latest generate yams \
-        --password "$(< "$first_install/config/dozzle/bootstrap-password.txt")" --user-roles none
-    assert_output_contains 'Dozzle bootstrap username: yams'
-    assert_output_contains "Dozzle bootstrap password: $(< "$first_install/config/dozzle/bootstrap-password.txt")"
-
-    INSTALL_DIR="$BATS_TEST_TMPDIR/install-two"
-    install_without_vpn
-
-    [ "$status" -eq 0 ]
-    ! cmp -s "$first_install/config/dozzle/users.yml" "$INSTALL_DIR/config/dozzle/users.yml"
+    grep -Fxq '  yams:' "$INSTALL_DIR/config/dozzle/users.yml"
+    grep -Fxq '    password: $2b$11$YaGI90TS5NAFFNM94LyGSeTxh4bXrmd4o2MU.blnaN8.d51YWTVJC' \
+        "$INSTALL_DIR/config/dozzle/users.yml"
+    grep -Fxq '    roles: none' "$INSTALL_DIR/config/dozzle/users.yml"
+    [ "$(stat -c %a "$INSTALL_DIR/config/dozzle/users.yml")" = 600 ]
+    [ ! -e "$INSTALL_DIR/config/dozzle/bootstrap-password.txt" ]
+    ! grep -Fq 'Dozzle bootstrap password:' <<<"$output"
+    ! grep -Fq $'\tdocker\trun\t' "$YAMS_DOCKER_LOG"
 }
 
 @test "keeps the custom Compose template unchanged and uses it at startup" {
@@ -329,8 +324,8 @@ EOF
 
     [ "$status" -eq 1 ]
     assert_output_contains 'Failed to start YAMS services'
-    [ -s "$INSTALL_DIR/config/dozzle/bootstrap-password.txt" ]
-    assert_output_contains "Dozzle bootstrap password: $(< "$INSTALL_DIR/config/dozzle/bootstrap-password.txt")"
+    [ ! -e "$INSTALL_DIR/config/dozzle/bootstrap-password.txt" ]
+    ! grep -Fq 'Dozzle bootstrap password:' <<<"$output"
     [ ! -e "$YAMS_SYSTEM_BIN/yams" ]
     [ ! -e "$HOME/yams_services.txt" ]
 }


### PR DESCRIPTION
The user never needs to be accessed or used. It simply exists to stop a Dozzle restart loop on initial start. The yams dozzle user is replaced by the YAMS guide-follower creating their own user.

The 'real' password is a 64 random character string that nobody will ever know!