### PR TITLE
remove leftover CLI file

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -667,6 +667,7 @@ install_cli() {
     echo
     log_info "Installing YAMS CLI..."
     if sudo cp "$install_directory/yams" /usr/local/bin/yams && sudo chmod +x /usr/local/bin/yams; then
+        sudo rm -f "$install_directory/yams"  # remove the original file in the installation directory since it has been installed succesfully
         log_success "YAMS CLI installed successfully ✅"
     else
         log_error "Failed to install YAMS CLI. Check permissions ❌"

--- a/src/install.sh
+++ b/src/install.sh
@@ -666,8 +666,7 @@ update_configuration_files() {
 install_cli() {
     echo
     log_info "Installing YAMS CLI..."
-    if sudo cp "$install_directory/yams" /usr/local/bin/yams && sudo chmod +x /usr/local/bin/yams; then
-        sudo rm -f "$install_directory/yams"  # remove the original file in the installation directory since it has been installed succesfully
+    if sudo mv "$install_directory/yams" /usr/local/bin/yams && sudo chmod +x /usr/local/bin/yams; then
         log_success "YAMS CLI installed successfully ✅"
     else
         log_error "Failed to install YAMS CLI. Check permissions ❌"


### PR DESCRIPTION
When running the installation script, the CLI is successfully installed but the template file it was copied from remains in the install directory.

Now it is deleted.