### PR TITLE
Fix incorrect port forwarding up and down commands

### DIFF
--- a/src/docker-compose.template.yaml
+++ b/src/docker-compose.template.yaml
@@ -42,8 +42,8 @@ services:
       # port forwarding settings
       - PORT_FORWARD_ONLY=on
       - VPN_PORT_FORWARDING=on
-      #- 'VPN_PORT_FORWARDING_UP_COMMAND=/bin/sh -c ''wget -O- --retry-connrefused --header="Authorization: Bearer ${QBITTORRENT_API_KEY}" --post-data "json={\"listen_port\":{{PORT}},\"current_network_interface\":\"{{VPN_INTERFACE}}\",\"random_port\":false,\"upnp\":false}" http://127.0.0.1:8081/api/v2/app/setPreferences 2>&1'''
-      #- 'VPN_PORT_FORWARDING_DOWN_COMMAND=/bin/sh -c ''wget -O- --retry-connrefused --header="Authorization: Bearer ${QBITTORRENT_API_KEY}" --post-data "json={\"listen_port\":0,\"current_network_interface\":\"lo\"}" http://127.0.0.1:8081/api/v2/app/setPreferences 2>&1'''
+      #- 'VPN_PORT_FORWARDING_UP_COMMAND=/bin/sh -c "wget -O- --retry-connrefused --header=\"Authorization: Bearer $${QBITTORRENT_API_KEY}\" --post-data \"json={\\\"listen_port\\\":{{PORT}}}\" http://127.0.0 2>&1"'
+      #- 'VPN_PORT_FORWARDING_DOWN_COMMAND=/bin/sh -c "wget -O- --retry-connrefused --header=\"Authorization: Bearer $${QBITTORRENT_API_KEY}\" --post-data \"json={\\\"listen_port\\\":0}\" http://127.0.0 2>&1"'
 
       - TZ=${TZ}
       #- HTTPPROXY=on

--- a/src/docker-compose.template.yaml
+++ b/src/docker-compose.template.yaml
@@ -42,8 +42,8 @@ services:
       # port forwarding settings
       - PORT_FORWARD_ONLY=on
       - VPN_PORT_FORWARDING=on
-      #- 'VPN_PORT_FORWARDING_UP_COMMAND=/bin/sh -c "wget -O- --retry-connrefused --header=\"Authorization: Bearer $${QBITTORRENT_API_KEY}\" --post-data \"json={\\\"listen_port\\\":{{PORT}}}\" http://127.0.0 2>&1"'
-      #- 'VPN_PORT_FORWARDING_DOWN_COMMAND=/bin/sh -c "wget -O- --retry-connrefused --header=\"Authorization: Bearer $${QBITTORRENT_API_KEY}\" --post-data \"json={\\\"listen_port\\\":0}\" http://127.0.0 2>&1"'
+      #- 'VPN_PORT_FORWARDING_UP_COMMAND=/bin/sh -c "wget -O- --retry-connrefused --header=\"Authorization: Bearer $${QBITTORRENT_API_KEY}\" --post-data \"json={\\\"listen_port\\\":{{PORT}}}\" http://127.0.0.1:8081/api/v2/app/setPreferences 2>&1"'
+      #- 'VPN_PORT_FORWARDING_DOWN_COMMAND=/bin/sh -c "wget -O- --retry-connrefused --header=\"Authorization: Bearer $${QBITTORRENT_API_KEY}\" --post-data \"json={\\\"listen_port\\\":0}\" http://127.0.0.1:8081/api/v2/app/setPreferences 2>&1"
 
       - TZ=${TZ}
       #- HTTPPROXY=on


### PR DESCRIPTION
They didn't work. These might? (Will be tested soon)

Made them more simple and ONLY touch the port setting though, doesn't mess with the interface or anything like that since the guide instructs how to lock it to `tun0`.