### PR TITLE
Delete http proxy port declaration

### DIFF
--- a/src/docker-compose.template.yaml
+++ b/src/docker-compose.template.yaml
@@ -53,7 +53,6 @@ services:
     ports:
       - 8081:8081/tcp # qbittorrent web UI routed through VPN
       - 8090:8080/tcp # sabnzbd web UI routed through VPN
-      # - 8888:8888/tcp # HTTP proxy for Prowlarr
     restart: unless-stopped
 
   # qBitorrent is used to download torrents


### PR DESCRIPTION
Since the only users of the proxy are container within the local Docker network, it does not have to be exposed at all. Even safer since no other machines can use it!