### PR TITLE
Remove MEDIA_SERVICE env var

### DIFF
--- a/src/.env.template
+++ b/src/.env.template
@@ -4,7 +4,6 @@ PGID=<your_PGID>
 TZ=<your_timezone>
 MEDIA_DIRECTORY=<media_directory>
 INSTALL_DIRECTORY=<install_directory>
-MEDIA_SERVICE=<media_service>
 
 # VPN configuration
 VPN_SERVICE=vpn_service
@@ -21,4 +20,3 @@ VPN_PASSWORD=vpn_password
 
 # service secrets (remember to uncomment when using them!)
 #QBITTORRENT_API_KEY=qbt_your_api_key
-

--- a/src/docker-compose.template.yaml
+++ b/src/docker-compose.template.yaml
@@ -1,8 +1,8 @@
 services:
   # <media_service> is used to serve your media to the client devices
   <media_service>:
-    image: lscr.io/linuxserver/${MEDIA_SERVICE}
-    container_name: ${MEDIA_SERVICE}
+    image: lscr.io/linuxserver/<media_service>
+    container_name: <media_service>
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
@@ -10,10 +10,10 @@ services:
       - VERSION=docker
     volumes:
       - ${MEDIA_DIRECTORY}:/data
-      - ${INSTALL_DIRECTORY}/config/${MEDIA_SERVICE}:/config
-    #network_mode: host # plex
-    ports: # comment out if using plex
-      - 8096:8096 # plex
+      - ${INSTALL_DIRECTORY}/config/<media_service>:/config
+    # network_mode: host # only required for Plex
+    ports: # not needed for Plex
+      - 8096:8096 # required for Jellyfin and Emby
     restart: unless-stopped
 
   # Gluetun is our VPN client

--- a/src/install.sh
+++ b/src/install.sh
@@ -544,7 +544,6 @@ update_configuration_files() {
            -e "s|<your_PGID>|$pgid|g" \
            -e "s|<your_timezone>|$tz|g" \
            -e "s|<media_directory>|$media_directory|g" \
-           -e "s|<media_service>|$media_service|g" \
            -e "s|<install_directory>|$install_directory|g" \
            -e "s|vpn_enabled|$setup_vpn|g" \
            -e 's|^#WIREGUARD_PRIVATE_KEY=.*|#WIREGUARD_PRIVATE_KEY=|' \
@@ -563,9 +562,9 @@ update_configuration_files() {
     # Handle Plex-Specific Networking
     if [ "$media_service" == "plex" ]; then
         log_info "Configuring Plex-specific settings..."
-        sed -i -e 's|#network_mode: host # plex|network_mode: host # plex|g' \
-               -e 's|ports: # comment out if using plex|#ports: # comment out if using plex|g' \
-               -e 's|- 8096:8096 # plex|#- 8096:8096 # plex|g' "$filename" || \
+        sed -i -e 's|# network_mode: host # only required for Plex|network_mode: host # required for Plex|g' \
+               -e 's|ports: # not needed for Plex|# ports: # not needed for Plex|g' \
+               -e 's|      - 8096:8096 # required for Jellyfin and Emby|    # - 8096:8096 # not needed for Plex|g' "$filename" || \
             log_error "Failed to configure Plex settings"
     fi
 

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -25,7 +25,6 @@ PGID=$(id -g)
 TZ=UTC
 MEDIA_DIRECTORY=$MEDIA_DIR
 INSTALL_DIRECTORY=$INSTALL_DIR
-MEDIA_SERVICE=jellyfin
 
 # VPN configuration
 VPN_SERVICE=
@@ -42,7 +41,6 @@ VPN_PASSWORD=
 
 # service secrets (remember to uncomment when using them!)
 #QBITTORRENT_API_KEY=qbt_your_api_key
-
 EOF
     ) "$INSTALL_DIR/.env"
 }
@@ -108,11 +106,26 @@ EOF
 
     [ "$status" -eq 0 ]
     assert_valid_install plex
-    grep -Fxq '    network_mode: host # plex' "$INSTALL_DIR/docker-compose.yaml"
+    grep -Fxq '    network_mode: host # required for Plex' "$INSTALL_DIR/docker-compose.yaml"
     grep -Fxq '    #network_mode: "service:gluetun"' "$INSTALL_DIR/docker-compose.yaml"
+    grep -Fxq '    image: lscr.io/linuxserver/plex' "$INSTALL_DIR/docker-compose.yaml"
+    grep -Fxq '    container_name: plex' "$INSTALL_DIR/docker-compose.yaml"
+    grep -Fxq '    # ports: # not needed for Plex' "$INSTALL_DIR/docker-compose.yaml"
     [ "$(grep -c 'profiles: \["disabled"\]' "$INSTALL_DIR/docker-compose.yaml")" -eq 3 ]
     ! grep -Eq '^[[:space:]]+- 8096:8096' "$INSTALL_DIR/docker-compose.yaml"
     grep -Fxq 'plex: http://192.0.2.10:32400/web' "$HOME/yams_services.txt"
+}
+
+@test "installs Jellyfin with media service ports and without host networking" {
+    install_without_vpn
+
+    [ "$status" -eq 0 ]
+    assert_valid_install jellyfin
+    grep -Fxq '    image: lscr.io/linuxserver/jellyfin' "$INSTALL_DIR/docker-compose.yaml"
+    grep -Fxq '    container_name: jellyfin' "$INSTALL_DIR/docker-compose.yaml"
+    grep -Fxq '    # network_mode: host # only required for Plex' "$INSTALL_DIR/docker-compose.yaml"
+    grep -Fxq '    ports: # not needed for Plex' "$INSTALL_DIR/docker-compose.yaml"
+    grep -Fxq '      - 8096:8096 # required for Jellyfin and Emby' "$INSTALL_DIR/docker-compose.yaml"
 }
 
 @test "installs OpenVPN with valid optional port forwarding callbacks" {

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -52,7 +52,10 @@ assert_valid_install() {
     [ -x "$YAMS_SYSTEM_BIN/yams" ]
     [ "$(stat -c %a "$INSTALL_DIR/.env")" = 600 ]
 
-    grep -q "^MEDIA_SERVICE=$expected_service$" "$INSTALL_DIR/.env"
+    ! grep -Eq '^MEDIA_.*SERVICE=' "$INSTALL_DIR/.env"
+    grep -q "^  $expected_service:$" "$INSTALL_DIR/docker-compose.yaml"
+    grep -q "^    image: lscr.io/linuxserver/$expected_service$" "$INSTALL_DIR/docker-compose.yaml"
+    grep -q "^    container_name: $expected_service$" "$INSTALL_DIR/docker-compose.yaml"
     ! grep -Eq '<[^>]+>|vpn_service|vpn_user|vpn_password|wireguard_(private_key|preshared_key|addresses)' \
         "$INSTALL_DIR/.env" "$INSTALL_DIR/docker-compose.yaml" "$INSTALL_DIR/yams"
     assert_command "$YAMS_DOCKER_LOG" docker compose \


### PR DESCRIPTION
Remove the media service env var.

I don't see the point of it being an environment variable, specially as things like the ports, network mode and container name in the docker compose are all fixed anyway, so the user can't change the env var for a simple switch anyway!

Things like the jellyfin/emby ports and the plex network mode still remain commented out with descriptions IF the user wants to swtch.